### PR TITLE
Add derive defaults to make building messages slightly easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ updated throughout the repository.
 
 ## [Unreleased]
 
+### Added
+- Most types now derive `Default` to improve the ergonomics of constructing messages.
+
 ## v0.1.0
 
 ### Added

--- a/examples/approval_template.rs
+++ b/examples/approval_template.rs
@@ -1,0 +1,48 @@
+use slack_bk::{
+    blocks::{Actions, Block, Section},
+    composition::Text,
+    elements::{Button, Element},
+    surfaces::Message,
+    util::Style,
+};
+
+fn main() {
+    let message = Message {
+        blocks: vec![
+            Block::Section(Section {
+                text: Some(Text::markdown("You have a new request:\n*<fakeLink.toEmployeeProfile.com|Fred Enriquez - New device request>*")),
+                ..Default::default()
+            }),
+            Block::Section(Section {
+                fields: vec![
+                    Text::markdown("*Type:*\nComputer (laptop)"),
+                    Text::markdown("*When:*\nSubmitted Aut 10"),
+                    Text::markdown("*Last Update:*\nMar 10, 2015 (3 years, 5 months)"),
+                    Text::markdown("*Reason:*\nAll vowel keys aren't working."),
+                    Text::markdown("*Specs:*\n\"Cheetah Pro 15\" - Fast, really fast\""),
+                ],
+                ..Default::default()
+            }),
+            Block::Actions(Actions {
+                elements: vec![
+                    Element::Button(Button {
+                        text: Text::plain("Approve"),
+                        style: Some(Style::Primary),
+                        value: Some("click_me_123".into()),
+                        ..Default::default()
+                    }),
+                    Element::Button(Button {
+                        text: Text::plain("Deny"),
+                        style: Some(Style::Danger),
+                        value: Some("click_me_123".into()),
+                        ..Default::default()
+                    })
+                ],
+                ..Default::default()
+            })
+        ],
+        ..Default::default()
+    };
+
+    serde_json::to_writer_pretty(std::io::stdout(), &message).unwrap();
+}

--- a/examples/message.rs
+++ b/examples/message.rs
@@ -33,8 +33,7 @@ fn main() {
                 block_id: None
             })
         ],
-        thread_ts: None,
-        mrkdwn: true,
+        ..Default::default()
     };
 
     serde_json::to_writer_pretty(std::io::stdout(), &message).unwrap();

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -16,7 +16,7 @@ pub enum Block {
     Section(Section),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Actions {
     pub elements: Vec<elements::Element>,
 
@@ -31,7 +31,7 @@ pub enum ContextElement {
     Text(Text),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Context {
     pub elements: Vec<ContextElement>,
 
@@ -39,7 +39,7 @@ pub struct Context {
     pub block_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Divider {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_id: Option<String>,
@@ -99,7 +99,7 @@ pub struct Input {
     pub optional: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Section {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<Text>,

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -28,7 +28,13 @@ impl Text {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+impl Default for Text {
+    fn default() -> Self {
+        Text::Markdown(Default::default())
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct MarkdownText {
     pub text: String,
 
@@ -36,7 +42,7 @@ pub struct MarkdownText {
     pub verbatim: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PlainText {
     pub text: String,
 
@@ -44,7 +50,7 @@ pub struct PlainText {
     pub emoji: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct ConfirmationDialog {
     pub title: Text,
     pub text: Text,
@@ -55,7 +61,7 @@ pub struct ConfirmationDialog {
     pub style: std::option::Option<Style>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Option {
     pub text: Text,
     pub value: String,
@@ -67,18 +73,18 @@ pub struct Option {
     pub url: std::option::Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct OptionGroup {
     pub label: Text,
     pub options: Vec<Option>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct DispatchAction {
     #[serde(default)]
     pub trigger_actions_on: Vec<String>,
 }
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct FilterAction {
     #[serde(default)]
     pub include: Vec<String>,

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -28,7 +28,7 @@ pub enum Element {
     TimePicker(TimePicker),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Button {
     pub text: Text,
     pub action_id: String,
@@ -46,7 +46,7 @@ pub struct Button {
     pub confirm: Option<composition::ConfirmationDialog>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct CheckboxGroup {
     pub action_id: String,
     pub options: Vec<composition::Option>,
@@ -54,7 +54,7 @@ pub struct CheckboxGroup {
     pub confirm: Option<composition::ConfirmationDialog>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct DatePicker {
     pub action_id: String,
     pub placeholder: Option<Text>,
@@ -68,7 +68,7 @@ pub struct Image {
     pub alt_text: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct MultiStaticSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -87,7 +87,7 @@ pub struct MultiStaticSelect {
     pub max_selected_items: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct MultiExternalSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -104,7 +104,7 @@ pub struct MultiExternalSelect {
     pub max_selected_items: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct MultiUsersSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -119,7 +119,7 @@ pub struct MultiUsersSelect {
     pub max_selected_items: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct MultiConversationsSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -140,7 +140,7 @@ pub struct MultiConversationsSelect {
     pub filter: Option<composition::FilterAction>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct MultiChannelsSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -155,7 +155,7 @@ pub struct MultiChannelsSelect {
     pub max_selected_items: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct OverflowMenu {
     pub action_id: String,
     pub options: Vec<composition::Option>,
@@ -164,7 +164,7 @@ pub struct OverflowMenu {
     pub confirm: Option<composition::ConfirmationDialog>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct PlainTextInput {
     pub action_id: String,
 
@@ -187,7 +187,7 @@ pub struct PlainTextInput {
     pub dispatch_action_config: Option<composition::DispatchAction>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct RadioButtonGroup {
     action_id: String,
     options: Vec<composition::Option>,
@@ -195,7 +195,7 @@ pub struct RadioButtonGroup {
     confirm: Option<composition::ConfirmationDialog>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct StaticSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -211,7 +211,7 @@ pub struct StaticSelect {
     pub confirm: Option<composition::ConfirmationDialog>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct ExternalSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -226,7 +226,7 @@ pub struct ExternalSelect {
     pub confirm: Option<composition::ConfirmationDialog>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct UsersSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -238,7 +238,7 @@ pub struct UsersSelect {
     pub confirm: Option<composition::ConfirmationDialog>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct ConversationsSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -259,7 +259,7 @@ pub struct ConversationsSelect {
     pub filter: Option<composition::FilterAction>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct ChannelsSelect {
     pub placeholder: Text,
     pub action_id: String,
@@ -274,7 +274,7 @@ pub struct ChannelsSelect {
     pub response_url_enabled: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct TimePicker {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placeholder: Option<Text>,

--- a/src/surfaces.rs
+++ b/src/surfaces.rs
@@ -21,7 +21,18 @@ fn default_mrkdwn() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+impl Default for Message {
+    fn default() -> Self {
+        Self {
+            text: None,
+            blocks: Vec::new(),
+            thread_ts: None,
+            mrkdwn: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Modal {
     pub title: Text,
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,3 +7,9 @@ pub enum Style {
     Primary,
     Danger,
 }
+
+impl Default for Style {
+    fn default() -> Self {
+        Style::Default
+    }
+}


### PR DESCRIPTION
enables usage of the following syntax:

```rust
Block::Section(Section {
    text: Some(
        Text::markdown(
            "You have a new request:\n*<fakeLink.toEmployeeProfile.com|Fred Enriquez - New device request>*"
         )),
    ..Default::default()
})
```